### PR TITLE
Fix for JRE 9+

### DIFF
--- a/src/main/java/org/eclipse/jdt/internal/jarinjarloader/JIJConstants.java
+++ b/src/main/java/org/eclipse/jdt/internal/jarinjarloader/JIJConstants.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2009 IBM Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * Copyright (c) 2007, 2017 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     Ferenc Hechler, ferenc_hechler@users.sourceforge.net - 262748 [jar exporter] extract constants for string literals in JarRsrcLoader et al.
@@ -32,4 +35,5 @@ final class JIJConstants {
 	static final String PATH_SEPARATOR                       = "/";  //$NON-NLS-1$
 	static final String CURRENT_DIR                          = "./";  //$NON-NLS-1$
 	static final String UTF8_ENCODING                        = "UTF-8";  //$NON-NLS-1$
+	static final String RUNTIME                              = "#runtime";  //$NON-NLS-1$
 }

--- a/src/main/java/org/eclipse/jdt/internal/jarinjarloader/JarRsrcLoader.java
+++ b/src/main/java/org/eclipse/jdt/internal/jarinjarloader/JarRsrcLoader.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2008, 2009 IBM Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     Ferenc Hechler - initial API and implementation
@@ -51,11 +54,26 @@ public class JarRsrcLoader {
 			else
 				rsrcUrls[i] = new URL(JIJConstants.JAR_INTERNAL_URL_PROTOCOL_WITH_COLON + rsrcPath + JIJConstants.JAR_INTERNAL_SEPARATOR);    
 		}
-		ClassLoader jceClassLoader = new URLClassLoader(rsrcUrls, null);
+		ClassLoader jceClassLoader = new URLClassLoader(rsrcUrls, getParentClassLoader());
 		Thread.currentThread().setContextClassLoader(jceClassLoader);
 		Class c = Class.forName(mi.rsrcMainClass, true, jceClassLoader);
 		Method main = c.getMethod(JIJConstants.MAIN_METHOD_NAME, new Class[]{args.getClass()}); 
 		main.invoke((Object)null, new Object[]{args});
+	}
+
+	private static ClassLoader getParentClassLoader() throws InvocationTargetException, IllegalAccessException {
+		// On Java8, it is ok to use a null parent class loader, but, starting with Java 9,
+		// we need to provide one that has access to the restricted list of packages that
+		// otherwise would produce a SecurityException when loaded
+		try {
+			// We use reflection here because the method ClassLoader.getPlatformClassLoader()
+			// is only present starting from Java 9
+			Method platformClassLoader = ClassLoader.class.getMethod("getPlatformClassLoader", (Class[])null); //$NON-NLS-1$
+			return (ClassLoader) platformClassLoader.invoke(null, (Object[]) null);
+		} catch (NoSuchMethodException e) {
+			// This is a safe value to be used on Java 8 and previous versions
+			return null;
+		}
 	}
 
 	private static ManifestInfo getManifestInfo() throws IOException {

--- a/src/main/java/org/eclipse/jdt/internal/jarinjarloader/RsrcURLConnection.java
+++ b/src/main/java/org/eclipse/jdt/internal/jarinjarloader/RsrcURLConnection.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2008, 2009 IBM Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     Ferenc Hechler - initial API and implementation

--- a/src/main/java/org/eclipse/jdt/internal/jarinjarloader/RsrcURLStreamHandler.java
+++ b/src/main/java/org/eclipse/jdt/internal/jarinjarloader/RsrcURLStreamHandler.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2009 IBM Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * Copyright (c) 2008, 2017 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     Ferenc Hechler - initial API and implementation
@@ -46,6 +49,8 @@ public class RsrcURLStreamHandler extends java.net.URLStreamHandler {
     		file = spec;
     	else if (url.getFile().endsWith(JIJConstants.PATH_SEPARATOR)) 
     		file = url.getFile() + spec;
+		else if (JIJConstants.RUNTIME.equals(spec))
+    		file = url.getFile();
     	else 
     		file = spec;
     	setURL(url, JIJConstants.INTERNAL_URL_PROTOCOL, "", -1, null, null, file, null, null);	 //$NON-NLS-1$ 

--- a/src/main/java/org/eclipse/jdt/internal/jarinjarloader/RsrcURLStreamHandlerFactory.java
+++ b/src/main/java/org/eclipse/jdt/internal/jarinjarloader/RsrcURLStreamHandlerFactory.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2008, 2009 IBM Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     Ferenc Hechler - initial API and implementation


### PR DESCRIPTION
Latest version of the _jar in jar loader_ from the [eclipse.jdt.ui repo](https://github.com/eclipse/eclipse.jdt.ui/tree/master/org.eclipse.jdt.ui/jar%20in%20jar%20loader/org/eclipse/jdt/internal/jarinjarloader).
Fix bug on JRE 9+: https://bugs.eclipse.org/bugs/show_bug.cgi?id=515921